### PR TITLE
Suppress warnings from ioctl.h

### DIFF
--- a/lib/CallBackery/Plugin.pm
+++ b/lib/CallBackery/Plugin.pm
@@ -463,7 +463,7 @@ sub getConfigValue {
     # warn "GET $key -> ".Dumper($ret);
     if ($@){
         die mkerror (3984,$@);
-    };
+    }
     return $ret->[0];
 }
 

--- a/lib/CallBackery/Plugin.pm
+++ b/lib/CallBackery/Plugin.pm
@@ -13,7 +13,8 @@ use IPC::Open3;
 use POSIX qw<F_SETFD F_GETFD FD_CLOEXEC>;
 use Time::HiRes qw(usleep);
 use Mojo::JSON qw(encode_json decode_json);
-eval { require "sys/ioctl.ph" };
+# disable warnings below, otherwise testing will give warnings
+eval { local $^W=0; require "sys/ioctl.ph" };
 
 =head1 NAME
 


### PR DESCRIPTION
When running tests ioctl.ph emits warnings.
While at it I removed a useless ; after an if statement.