### PR TITLE
Allow hidden text fields (e.g. for database id fields in edit forms)

### DIFF
--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/form/Auto.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/form/Auto.js
@@ -88,6 +88,11 @@ qx.Class.define("callbackery.ui.form.Auto", {
                     control = new qx.ui.form.TextArea();
                     tm[s.key] = 'text';
                     break;
+                case 'hiddenText':
+                    control = new qx.ui.form.TextField();
+                    control.exclude();
+                    tm[s.key] = 'text';
+                    break;
 
                 case 'checkBox':
                     control = new qx.ui.form.CheckBox();


### PR DESCRIPTION
A none-speaking primary key is not relevant to the user of an application.