### PR TITLE
Update Action.js

### DIFF
--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Action.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Action.js
@@ -179,7 +179,9 @@ qx.Class.define("callbackery.ui.plugin.Action", {
                                     popup.dispose();
                                     this.fireEvent('popupClosed');
                                 },this,100);
-                                this.fireDataEvent('actionResponse',{action: 'reload'});
+                                if (!btnCfg.option && !btnCfg.option.noReload){
+                                    this.fireDataEvent('actionResponse',{action: 'reload'});
+                                }
                             },this);
                             popup.open();
                             break;


### PR DESCRIPTION
Within actionCfg, you may set 
option => {
                noReload => 1,
            },
to prevent reloading data when the popup is beeing closed.
This may be useful when the popup is readonly.