### PR TITLE
Add docu, touch en.po

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,8 @@ my-call-backery-app/
 *.gz
 *.tar
 dist.sh
+
+# Backup files
 *~
+*.swp
+*#

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ applications with a desktopish look and feel.  For many applications, all
 you have todo is write a few lines of perl code and all the rest is taken
 care of by CallBackery.
 
-To get you started, CallBackery comes with a sample application ... 
+To get you started, CallBackery comes with a sample application ...
 
 Quickstart
 ----------
@@ -19,7 +19,7 @@ ubuntu 14.04 but they should work on any recent linux system with at least
 perl 5.10.1 installed.
 
 First make sure you have gcc, perl curl and automake installed. The following commands
-will work on debian and ubuntu. 
+will work on debian and ubuntu.
 
 ```console
 sudo apt-get install curl automake perl gcc unzip
@@ -50,12 +50,39 @@ Finally lets generate the CallBackery sample application.
 mkdir -p ~/src
 cd ~/src
 mojo generate callbackery_app CbDemo
-cd cb_demo
+cd cb-demo
 ```
 
 Et voilà, you are looking at your first CallBackery app. To get the
-sample application up and running, follow the instructions in the 
+sample application up and running, follow the instructions in the
 README you find in the `cb_demo` directory.
+
+Developing / Contributing
+-------------------------
+- Fork this repo (Using the github UI: https://github.com/oetiker/callbackery -> "Fork" in the top-right corner
+- Clone your repo (In your fork, push "Clone or Download" and use the URL there for you `git clone` command)
+```console
+cd
+mkdir -p checkouts
+cd checkouts
+# your git clone command, here
+cd callbackery
+```
+- Make a branch (You will PR that branch, later)
+
+Generate the demo app from your checkout
+```console
+cd ~/checkouts/callbackery
+perl Makefile.pl
+cd
+mkdir -p src
+cd src
+perl -I ~/checkouts/callbackery/thirdparty/lib/perl5 -I ~/checkouts/callbackery/lib ~/checkouts/callbackery/thirdparty/bin/mojo generate callbackery_app CbDemo
+```
+Now, proceed with the README in `~/src/cb-demo`
+
+To create a PR, commit your changes, push them to your github repo, and use the github UI to create the PR to `https://github.com/oetiker/callbackery`.
+Chances for a merge are improved if you explain in some detail what your changes are and what they achieve.
 
 
 Enjoy

--- a/lib/Mojolicious/Command/Author/generate/callbackery_app/Makefile.am
+++ b/lib/Mojolicious/Command/Author/generate/callbackery_app/Makefile.am
@@ -42,6 +42,7 @@ clean-local:
 
 share/messages.pot: $(PM)
 	mkdir -p share
+	touch share/en.po
 	$(XGETTEXT) --language=perl --package-name=$(PACKAGE) --package-version=$(VERSION) --from-code=UTF-8 --keyword=trm:1 --output=share/messages.pot $(PM)
 	for lang in share/*.po; do \
 		$(MSGMERGE) -U $$lang share/messages.pot; \

--- a/lib/Mojolicious/Command/Author/generate/callbackery_app/README
+++ b/lib/Mojolicious/Command/Author/generate/callbackery_app/README
@@ -45,7 +45,8 @@ using the built-in Mojo webserver.
   cd ../bin
   ./<%= $p->{name} %>-source-mode.sh
 
-You can now connect to the CallBackery app with your web browser.
+You can now connect to the CallBackery app with your web browser. Just point it at `localhost:5444`.
+(If port 5444 is already used, change it in the last line of `./<%= $p->{name} %>-source-mode.sh`.)
 
 If you need any additional perl modules, write their names into the PERL_MODULES
 file and run ./bootstrap.


### PR DESCRIPTION
This does 2 things.

1. Add some docu on how to use the checkout for development (instead of downloading master.tar.gz from github
and using that to build the callbackery tools in `~/opt/callbackery`.
Also, correct a very minor glitch in `README.md`

2. Previously, the `make` of the demo app failed, because no `source.*.po` files were present.
Now, we just touch `en.po` in the Makefile and it is happy.