### PR TITLE
No spacing form renderer

### DIFF
--- a/lib/CallBackery/Controller/RpcService.pm
+++ b/lib/CallBackery/Controller/RpcService.pm
@@ -5,7 +5,7 @@ use CallBackery::Exception qw(mkerror);
 use CallBackery::User;
 # use Data::Dumper;
 use Scalar::Util qw(blessed weaken);
-use Mojo::JSON qw(encode_json decode_json);
+use Mojo::JSON qw(encode_json decode_json from_json);
 
 =head1 NAME
 
@@ -527,7 +527,7 @@ sub handleDownload {
 
     my $form;
     if (my $formData = $self->req->param('formData')){
-        $form = eval { decode_json($formData) };
+        $form = eval { from_json($formData) };
         if ($@){
             return $self->render(text=>encode_json({exception=>{message=>'Data Decoding Problem '.$@,code=>3923}}));
         }

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/form/renderer/NoteForm.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/form/renderer/NoteForm.js
@@ -26,6 +26,7 @@ qx.Class.define("callbackery.ui.form.renderer.NoteForm", {
         fl.setColumnMinWidth(1, 130);
         fl.setColumnFlex(2,1);
         fl.setColumnMaxWidth(2,250);
+        fl.setSpacingY(0);
     },
 
     members: {
@@ -48,8 +49,16 @@ qx.Class.define("callbackery.ui.form.renderer.NoteForm", {
             // add the items
             for (var i = 0; i < items.length; i++) {
                 var label = this._createLabel(names[i], items[i]);
+                label.set({
+                    marginTop: 2,
+                    marginBottom: 2
+                });
                 this._add(label, {row: this._row, column: 0});
                 var item = items[i];
+                item.set({
+                    marginTop: 2,
+                    marginBottom: 2
+                });
                 label.setBuddy(item);
                 this._add(item, {row: this._row, column: 1});
                 if (itemOptions != null && itemOptions[i] != null && itemOptions[i].note ){


### PR DESCRIPTION
Use top/bottom margins around labels and inputs instead of vertical grid spacing to allow full exclusion of form elements