### PR TITLE
`tra`: translate %2, %3 etc also

### DIFF
--- a/lib/CallBackery/Translate.pm
+++ b/lib/CallBackery/Translate.pm
@@ -91,6 +91,7 @@ sub tra {
     my $id = 1;
     for my $a (@args){
         $str =~ s/%$id/$a/g;
+        $id++;
     }
     return $str;
 }


### PR DESCRIPTION
The increment of `$id` was missing, which is now fixed.