### PR TITLE
Remove undefined case for action handler again

### DIFF
--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Action.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Action.js
@@ -52,10 +52,9 @@ qx.Class.define("callbackery.ui.plugin.Action", {
                 case 'reload':
                 case 'cancel':
                 case 'wait':
-                case undefined:
                     break;
                 default:
-                    console.error('Unknown action', data.action);
+                    console.error('Unknown action:', data.action);
                     break;
             }
         },this);


### PR DESCRIPTION
This was just not a good idea as the backend could return unJsonable data and produce a warning that is difficult to track done.

I wonder if it is a good idea to allow/ignore empty returns (see line 26)