### PR TITLE
Skip if button has no action

### DIFF
--- a/lib/CallBackery/GuiPlugin/AbstractForm.pm
+++ b/lib/CallBackery/GuiPlugin/AbstractForm.pm
@@ -288,6 +288,7 @@ sub massageConfig {
     my $cfg = shift;
     my $actionCfg = $self->actionCfg;
     for my $button (@$actionCfg){
+        next unless $button->{action};
         if ($button->{action} =~ /popup|wizzard/) {
             # prepend plugin name (see also screenCfg above)
             my $name = $self->name . '_' . $button->{name};


### PR DESCRIPTION
Such a scenario could be possible if based on certain conditions, an action (and their respective button) is available or not.

```perl
# actionCfg 
[
    ...
   $condition ? {
          action => 'submit',
          ...
   }: {},
]
```