### PR TITLE
Make login window more compact and logo scale optional

### DIFF
--- a/lib/CallBackery/Config.pm
+++ b/lib/CallBackery/Config.pm
@@ -179,8 +179,8 @@ DOC
         },
         FRONTEND => {
             _doc => 'Settings for the Web FRONTEND',
-            _vars => [ qw(logo logo_small spinner title initial_plugin company_name company_url company_support
-			  hide_password hide_release hide_company max_width
+            _vars => [ qw(logo logo_small logo_scale spinner title initial_plugin company_name company_url company_support
+			  hide_password hide_password_icon hide_release hide_company max_width
 			)
                      ],
             logo => {
@@ -201,6 +201,9 @@ DOC
             logo_small => {
                 _doc => 'url for the small logo brand the UI',
             },
+            logo_scale => {
+                _doc => 'should logo on login window be scaled',
+            },
             spinner => {
                 _doc => 'url for the busy animation spinner gif',
             },
@@ -212,6 +215,11 @@ DOC
             },
             hide_password => {
 	        _doc => 'hide password field on login screen',
+	        _re => '(yes|no)',
+                _re_error => 'pick yes or no',
+            },
+            hide_password_icon => {
+	        _doc => 'hide password icon on login screen',
 	        _re => '(yes|no)',
                 _re_error => 'pick yes or no',
             },

--- a/lib/CallBackery/Model/ConfigJsonSchema.pm
+++ b/lib/CallBackery/Model/ConfigJsonSchema.pm
@@ -223,6 +223,9 @@ properties:
         description: for the small logo brand the UI
         type: string
         format: uri
+      logo_scale:
+        description: should the log be scaled on the login window
+        type: boolean
       spinner:
         type: string
         format: uri
@@ -236,6 +239,9 @@ properties:
       hide_password:
         type: boolean
         description: hide password field on login screen
+      hide_password_icon:
+        type: boolean
+        description: hide password dialog icon
       hide_release:
         type: boolean
         description: hide release string on login screen

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/Login.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/Login.js
@@ -31,26 +31,24 @@ qx.Class.define("callbackery.ui.Login", {
         el.insertInto(form);
 
         this.set({
-            modal                : true,
-            showMinimize         : false,
-            showMaximize         : false,
-            showClose            : false,
-            resizable            : false,
-            allowGrowX: true,
-            allowShrinkX: true,
-            allowGrowY: true,
-            allowShrinkY: true,
-            contentPaddingLeft   : 30,
-            contentPaddingRight  : 30,
-            contentPaddingTop    : 20,
-            contentPaddingBottom : 20,
-            width                : 500,
-            centerOnContainerResize: true,
-            centerOnAppear: true
+            modal                   : true,
+            showMinimize            : false,
+            showMaximize            : false,
+            showClose               : false,
+            resizable               : false,
+            allowGrowX              : true,
+            allowShrinkX            : true,
+            allowGrowY              : true,
+            allowShrinkY            : true,
+            contentPaddingLeft      : 30,
+            contentPaddingRight     : 30,
+            contentPaddingTop       : 20,
+            contentPaddingBottom    : 20,
+            centerOnContainerResize : true,
+            centerOnAppear          : true
         });
         this.getApplicationRoot().addListener('resize',this.__setMaxWidth,this);
         this.__setMaxWidth();
-        this.addListener('resize',() => { this.center()});
         this.getChildControl('captionbar').exclude();
         this.getChildControl('pane').set({
             decorator : new qx.ui.decoration.Decorator().set({
@@ -63,9 +61,8 @@ qx.Class.define("callbackery.ui.Login", {
         var grid = new qx.ui.layout.Grid(10, 10);
         this.setLayout(grid);
         grid.setColumnAlign(1, 'right', 'middle');
-        grid.setColumnFlex(0,2);
-        //grid.setColumnWidth(0, 120);
-        //grid.setColumnWidth(2, 160);
+        let logoScale = (cfg.logo_scale != undefined) ? cfg.logo_scale : true;
+        let logoSpan  = logoScale ? 3 : 1; 
         if (cfg.logo){
             this.add(new qx.ui.basic.Image(cfg.logo).set({
                 alignX : 'left',
@@ -73,16 +70,15 @@ qx.Class.define("callbackery.ui.Login", {
                 allowShrinkX: true,
                 allowGrowY: true,
                 allowShrinkY: true,
-                scale: true
-
+                scale: logoScale
             }), {
                 row     : 0,
                 column  : 0,
-                colSpan : 3
+                colSpan : logoSpan
             });
         }
 
-        if (! cfg.hide_password) {
+        if (! cfg.hide_password && ! cfg.hide_password_icon) {
             this.add(new qx.ui.basic.Image("icon/64/status/dialog-password.png").set({
                 alignY : 'top',
                 alignX : 'right',


### PR DESCRIPTION
- Allow disabling of logo scaling
- Make it a bit more compact
- Remove unnecessary resize callback
- Allow hiding of keys logo

This should be mostly viusally backward compatible.
