### PR TITLE
URI Automation Patch

### DIFF
--- a/lib/CallBackery/GuiPlugin/AbstractForm.pm
+++ b/lib/CallBackery/GuiPlugin/AbstractForm.pm
@@ -131,7 +131,7 @@ an error message.
 sub validateData {
     my $self = shift;
     my $fieldName = shift;
-    my $formData = shift;
+    my $formData = shift || {};
     my $entry = $self->formCfgMap->{$fieldName};
     if (not ref $entry){
         die mkerror(4095,trm("sorry, don't know the field you are talking about"));

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/Application.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/Application.js
@@ -86,19 +86,9 @@ qx.Class.define("callbackery.Application", {
         },
 
         __changeLanguage: function() {
-            var h = qx.bom.History.getInstance();
-            var state = h.getState();
-            var items = state.split(';');
-            var lang;
-            for (var i=0; i<items.length; i++) {
-                var item = items[i].split('=');
-                if (item[0] == 'lang') {
-                    lang = decodeURIComponent(item[1]);
-                    break;
-                }
-            }
-            if (lang) {
-                qx.locale.Manager.getInstance().setLocale(lang);
+            var urlCfg = callbackery.data.Config.getInstance().getUrlConfig();
+            if (urlCfg.lang) {
+                qx.locale.Manager.getInstance().setLocale(urlCfg.lang);
             }
         },
 

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/data/Config.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/data/Config.js
@@ -37,7 +37,7 @@ qx.Class.define('callbackery.data.Config', {
             if (base){
                 base[1].split(/;/).forEach(function(kv){
                     var list = kv.split('=');
-                    ha[list[0]] = list[1];
+                    ha[list[0]] = decodeURIComponent(list[1]);
                 });
             }
             return ha;

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/Login.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/Login.js
@@ -156,16 +156,18 @@ qx.Class.define("callbackery.ui.Login", {
             colSpan: 3
         });
         if (cfg.passwordreset_popup) {
-            extraActions.add(
-                this.__makeExtraButton(
-                    cfg.passwordreset_popup,this.tr("Reset Password"))
+            let btn = this.__passwordresetBtn = this.__makeExtraButton(
+                cfg.passwordreset_popup,this.tr("Reset Password")
             );
+            extraActions.add(btn);
+            
+
         }
         if (cfg.registration_popup) {
-            extraActions.add(
-                this.__makeExtraButton(
-                    cfg.registration_popup,this.tr("Register New Account"))
+            let btn = this.__registrationBtn = this.__makeExtraButton(
+                cfg.registration_popup,this.tr("Register New Account")
             );
+            extraActions.add(btn);
         }
         
         if ( cfg.company_name && !cfg.hide_company){
@@ -214,6 +216,7 @@ qx.Class.define("callbackery.ui.Login", {
         },
         this);
 
+        let urlCfg = callbackery.data.Config.getInstance().getUrlConfig();
         this.addListener('appear', function() {
             if (! cfg.hide_password) {
                 password.setValue('');
@@ -235,6 +238,12 @@ qx.Class.define("callbackery.ui.Login", {
                 username.activate();
             }
             this.__ensureIframe();
+            if (urlCfg.app === 'registration' && this.__registrationBtn){
+                this.__registrationBtn.fireEvent('tap');
+            }
+            else if (urlCfg.app === 'passwordreset' && this.__passwordresetBtn){
+                this.__passwordresetBtn.fireEvent('tap');
+            }
         },this);
     },
 
@@ -249,6 +258,8 @@ qx.Class.define("callbackery.ui.Login", {
          * @return {void}
          */
         __iframe: null,
+        __passwdBtn: null,
+        __registrationBtn: null,
         __ensureIframe: function(){
             var iframe = document.getElementById("cbLoginIframe");
             if (!iframe) {

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/Popup.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/Popup.js
@@ -72,8 +72,8 @@ qx.Class.define("callbackery.ui.Popup", {
                 case 'wait':
                 case 'dataModified':
                 case 'reloadStatus':
-                    break;
                 case 'showMessage':
+                        break;
                 case 'dataSaved':
                 case 'cancel':
                     this.close();

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
@@ -30,8 +30,27 @@ qx.Class.define("callbackery.ui.plugin.Form", {
         this._getParentFormData = getParentFormData;
         this._populate();
         this._addValidation();
+
+        let urlCfg = callbackery.data.Config.getInstance().getUrlConfig();
+
         this.addListener('appear',function () {
             this._loadData();
+            let data = {};
+            let gotData = false;
+            for (let key in urlCfg){
+                let match = key.match(/^set_(.+)/);
+                if (match !== null){
+                    data[match[1]] = urlCfg[key];
+                    gotData = true;
+                }
+            }
+            if (gotData) {
+                this._form.setData(data,true);
+                //this._reconfForm();
+                if (urlCfg.cleanup) {
+                    window.location.hash = '';
+                }
+            }
         }, this);
         // a map of pending reconfigure requests. The keys are the
         // names of the fields for which we postponed reconfiguration.
@@ -180,8 +199,7 @@ qx.Class.define("callbackery.ui.plugin.Form", {
                     }
                 };
                 if (control.getSelection){
-                    control.addListener('changeSelection',callback,this);
-                }
+                    control.getSelection().addListener("change", callback, this);                }
                 else {
                     control.addListener('changeValue',callback,this);
                 }


### PR DESCRIPTION
New Features

* access registration app as `app=registration`
* access passwordreset app as `app=passwordreset`
* prefill form fields with `set_{$key}=value`
* cleanup  hash url with `cleanup=1`

Bugfix

* do not close popup on showMessage
* emit selection event on change selection in popup

Example:

`http://127.0.0.1:3626/#app=registration;set_email=dummy@address;set_token=ebc4g90d2;cleanup=1`

