### PR TITLE
Collect multiple card input updates with timer

### DIFF
--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/Card.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/Card.js
@@ -175,29 +175,38 @@ qx.Class.define("callbackery.ui.Card", {
                             });
                         }
                         else {
+                            // For input fields we collect multiple fast inputs and only store
+                            // if no new input events occur for a certain time
+                            let delay = 500; // msec
                             let updateTimer, lastValue;
-                            field.addListener(event, (e) => {
-                                if (!updateTimer) { // create on first input update
-                                    updateTimer = new qx.event.Timer(500);
-                                    // save input when timer expires and value changed
-                                    updateTimer.addListener("interval", function() {
-                                        updateTimer.stop();
-                                        let value = field.getValue();
-                                        if (value === lastValue) {
-                                            return;
-                                        }
-                                        lastValue = value;
-                                        this.__parentForm.setSelection({ data : this.__dataCache, key : fieldCfg.key, value : value });
-                                        if (this.__buttonMap[this._updateAction]) {
-                                            this.__buttonMap[this._updateAction].execute();
-                                        }
-                                        else {
-                                            console.warn('No method for updateCard:', this._updateAction);
-                                        }
-                                    }, this);
+
+                            // store input callback for updateTimer
+                            let storeInput = () => {
+                                updateTimer.stop();
+                                let value = field.getValue();
+                                if (value === lastValue) {
+                                    return;
                                 }
-                                else { // reset timer on further input updates
+                                lastValue = value;
+                                this.__parentForm.setSelection({ data : this.__dataCache, key : fieldCfg.key, value : value });
+                                if (this.__buttonMap[this._updateAction]) {
+                                    this.__buttonMap[this._updateAction].execute();
+                                }
+                                else {
+                                    console.warn('No method for updateCard:', this._updateAction);
+                                }
+                            };
+
+                            // called on inputs into the field
+                            field.addListener(event, (e) => {
+                                if (updateTimer) {
+                                    // delay storing on repeated inputs while timer is running
                                     updateTimer.restart();
+                                }
+                                else {
+                                    // create and start timer on first input
+                                    updateTimer = new qx.event.Timer(delay);
+                                    updateTimer.addListener("interval", storeInput, this);
                                 }
                             });
                         }


### PR DESCRIPTION
Some fast inputs where lost:
- Collect multiple inputs with a timer
- Use input value instead of event value
- Store only if value changed