### PR TITLE
Action.js: Avoid JSON parse errors

### DIFF
--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Action.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Action.js
@@ -300,7 +300,21 @@ qx.Class.define("callbackery.ui.plugin.Action", {
                                         }
                                     };
                                     try {
-                                        response = qx.lang.Json.parse(iframe.getBody().innerHTML);
+                                        // innerHTML is wrapped in `<pre>` tags, which we remove.
+                                        innerHTML = iframe.getBody().innerHTML;
+                                        if (innerHTML) {
+                                            innerHTML = innerHTML.replace(/^<.*?>/, '');
+                                            innerHTML = innerHTML.replace(/<.*?>$/, '');
+                                        }
+                                        // If there is text left, it should be the json from the server.
+                                        // JSON parsing an empty string is an error.
+                                        if (innerHTML) {
+                                            response =  qx.lang.Json.parse(innerHTML);
+                                        }
+                                        // otherwise remove standard exception.
+                                        else {
+                                            response = '';
+                                        }
                                     } catch (e){};
                                     if (response.exception){
                                         callbackery.ui.MsgBox.getInstance().error(


### PR DESCRIPTION
In Chrome and Firefox, `innerHTML` we get from the backend is
wrapped in (different) forms of `<pre></pre>`.
(Chrome has additional inline styling.)

Remove these tags before trying to parse it as JSON.

Also, parsing an empty string is an error, which still got us the standard "9999 No Data" error.