### PR TITLE
Make URL form setting consistent with URL action calling

### DIFF
--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/form/Auto.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/form/Auto.js
@@ -113,7 +113,7 @@ qx.Class.define("callbackery.ui.form.Auto", {
                     tm[s.key] = 'date';
                     break;
 
-               case 'dateTime':
+                case 'dateTime':
                     control = new callbackery.ui.form.DateTime().set({
                         dateFormat  : new qx.util.format.DateFormat(this.tr("dd.MM.yyyy"))
                     });

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
@@ -43,24 +43,8 @@ qx.Class.define("callbackery.ui.plugin.Form", {
         this.setQxObjectId(cfg.name);
 
         this.addListener('appear',function () {
-            this._loadData(
-                () => {
-
-                    let data    = {};
-                    let gotData = false;
-                    let config  = callbackery.data.Config.getInstance();
-                    this._urlFormElements.forEach(urlFormElement => {
-                        let urlValue = config.getUrlConfigValue(urlFormElement.urlKey);
-                        if (urlValue) {
-                            data[urlFormElement.formKey] = urlValue;
-                            // only do it once for the time being
-                            config.removeUrlConfigEntry(urlFormElement.urlKey);
-                            gotData = true;
-                        }
-                    });
-                    return data;
+            this._loadData(true);
                 }
-            );
         }, this);
 
         // a map of pending reconfigure requests. The keys are the
@@ -332,7 +316,23 @@ qx.Class.define("callbackery.ui.plugin.Form", {
                 that._loading--;
             },'getPluginData',this._cfg.name,'allFields',parentFormData,{ currentFormData: this._form.getData()});
         },
-        _loadData: function(callback){
+        _getUrlData: function () {
+                    let data    = {};
+                    let gotData = false;
+                    let config  = callbackery.data.Config.getInstance();
+                    this._urlFormElements.forEach(urlFormElement => {
+                        let urlValue = config.getUrlConfigValue(urlFormElement.urlKey);
+                        if (urlValue) {
+                            data[urlFormElement.formKey] = urlValue;
+                            // only do it once for the time being
+                            config.removeUrlConfigEntry(urlFormElement.urlKey);
+                            gotData = true;
+                        }
+                    });
+                    return data;
+                }
+         }
+        _loadData: function(mergeUrlData){
             if (!this._form) return;
 
             var that = this;
@@ -346,9 +346,8 @@ qx.Class.define("callbackery.ui.plugin.Form", {
             busy.show(this.tr('Loading Form Data'));
             rpc.callAsync(function(data,exc){
                 if (!exc){
-                    let urlData;
-                    if (callback) {
-                        urlData = callback();
+                    if (mergeUrlData) {
+                        urlData = this._getUrlData();
                         if (!data) {
                             data = urlData;
                         }

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
@@ -44,7 +44,6 @@ qx.Class.define("callbackery.ui.plugin.Form", {
 
         this.addListener('appear',function () {
             this._loadData(true);
-                }
         }, this);
 
         // a map of pending reconfigure requests. The keys are the

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
@@ -19,10 +19,17 @@ qx.Class.define("callbackery.ui.plugin.Form", {
     construct : function(cfg,getParentFormData) {
         this.base(arguments);
         var that = this;
+        this._urlFormElements = [];
         if (cfg.form != null) {
             cfg.form.forEach(function(s){
                 if (s.triggerFormReset) {
                     that._hasTrigger = true;
+                }
+                if (s.urlFormKey) {
+                    that._urlFormElements.push({
+                        urlKey  : s.urlFormKey,
+                        formKey : s.key,
+                    });
                 }
             });
         }
@@ -36,22 +43,29 @@ qx.Class.define("callbackery.ui.plugin.Form", {
         this.setQxObjectId(cfg.name);
 
         this.addListener('appear',function () {
-            this._loadData();
-            let data = {};
-            let gotData = false;
-            let urlCfg = callbackery.data.Config.getInstance().getUrlConfig();
-            for (let key in urlCfg){
-                let match = key.match(/^set_(.+)/);
-                if (match !== null){
-                    data[match[1]] = urlCfg[key];
-                    gotData = true;
+            this._loadData(
+                () => {
+
+                    let data    = {};
+                    let gotData = false;
+                    let config  = callbackery.data.Config.getInstance();
+                    this._urlFormElements.forEach(urlFormElement => {
+                        let urlValue = config.getUrlConfigValue(urlFormElement.urlKey);
+                        if (urlValue) {
+                            data[urlFormElement.formKey] = urlValue;
+                            // only do it once for the time being
+                            config.removeUrlConfigEntry(urlFormElement.urlKey);
+                            gotData = true;
+                        }
+                    });
+                    if (gotData) {
+                        this._form.setData(data,true);
+                        //this._reconfForm();
+                    }
                 }
-            }
-            if (gotData) {
-                this._form.setData(data,true);
-                //this._reconfForm();
-            }
+            );
         }, this);
+
         // a map of pending reconfigure requests. The keys are the
         // names of the fields for which we postponed reconfiguration.
         // With that we avoid multi-reconfiguration per field.
@@ -92,6 +106,7 @@ qx.Class.define("callbackery.ui.plugin.Form", {
     },
     members: {
         _form: null,
+        _urlFormElements: null,
         _action: null,
         _cfg: null,
         _loading: null,
@@ -320,7 +335,7 @@ qx.Class.define("callbackery.ui.plugin.Form", {
                 that._loading--;
             },'getPluginData',this._cfg.name,'allFields',parentFormData,{ currentFormData: this._form.getData()});
         },
-        _loadData: function(){
+        _loadData: function(callback){
             if (!this._form) return;
 
             var that = this;
@@ -348,6 +363,9 @@ qx.Class.define("callbackery.ui.plugin.Form", {
                 }
                 busy.hide();
                 that._loading--;
+                if (callback) {
+                    callback();
+                }
             },'getPluginData',this._cfg.name,'allFields',parentFormData,{ currentFormData: this._form.getData()});
         }
     },

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
@@ -331,7 +331,7 @@ qx.Class.define("callbackery.ui.plugin.Form", {
                     });
                     return data;
                 }
-         }
+         },
         _loadData: function(mergeUrlData){
             if (!this._form) return;
 

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/ui/plugin/Form.js
@@ -58,10 +58,7 @@ qx.Class.define("callbackery.ui.plugin.Form", {
                             gotData = true;
                         }
                     });
-                    if (gotData) {
-                        this._form.setData(data,true);
-                        //this._reconfForm();
-                    }
+                    return data;
                 }
             );
         }, this);
@@ -349,6 +346,16 @@ qx.Class.define("callbackery.ui.plugin.Form", {
             busy.show(this.tr('Loading Form Data'));
             rpc.callAsync(function(data,exc){
                 if (!exc){
+                    let urlData;
+                    if (callback) {
+                        urlData = callback();
+                        if (!data) {
+                            data = urlData;
+                        }
+                        else {
+                            Object.assign(data, urlData);
+                        }
+                    }
                     if (that._form) {
                         that._form.setData(data,true);
                         if (that._hasTrigger) {
@@ -363,9 +370,6 @@ qx.Class.define("callbackery.ui.plugin.Form", {
                 }
                 busy.hide();
                 that._loading--;
-                if (callback) {
-                    callback();
-                }
             },'getPluginData',this._cfg.name,'allFields',parentFormData,{ currentFormData: this._form.getData()});
         }
     },


### PR DESCRIPTION
Allow form entries from URL with
```
        {
            key    => 'nevis_test',
            label  => trm('Test'),
            widget => 'text',
            set    => {
                required => true,
                maxWidth => 300,
            },
            urlFormKey => 'test',
        },
```
in backend with URL `http://localhost:7181/#app=HINPassword;test=test`.

**Note:** Backward-incompatible change (of none-documented feature).