### PR TITLE
Catch instantiation failure

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
-  - remove dot after company name/link in footer
+- catch plugin instanciation error
+- remove dot after company name/link in footer
 
 0.42.1 2022-05-12 22:56:43 +0200 Tobias Oetiker <tobi@oetiker.ch>
 

--- a/lib/CallBackery/Controller/RpcService.pm
+++ b/lib/CallBackery/Controller/RpcService.pm
@@ -253,8 +253,13 @@ async sub instantiatePlugin_p {
     my $name = shift;
     my $args = shift;
     my $user = $self->user;
-    my $plugin = await $self->config->instantiatePlugin_p($name,$user,$args);
-    $plugin->log($self->log);
+    my $plugin;
+    try {
+        $plugin = await $self->config->instantiatePlugin_p($name,$user,$args);
+    } catch($error) {
+        warn $error;
+    }
+    $plugin->log($self->log) if $plugin;
     return $plugin;
 }
 

--- a/lib/CallBackery/Controller/RpcService.pm
+++ b/lib/CallBackery/Controller/RpcService.pm
@@ -256,10 +256,10 @@ async sub instantiatePlugin_p {
     my $plugin;
     try {
         $plugin = await $self->config->instantiatePlugin_p($name,$user,$args);
+        $plugin->log($self->log);
     } catch($error) {
-        warn $error;
+        $self->log->warn($error);
     }
-    $plugin->log($self->log) if $plugin;
     return $plugin;
 }
 


### PR DESCRIPTION
Avoid `Unhandled rejected promise` warning on failed plugin instantiation (e.g. if user has no access)