### PR TITLE
Migrate RPC to JSON-RPC 2.0 (qooxdoo 7.x; replace deprecated qx.io.remote)

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - ubuntu-22.04
           # no libssl on windows
           # - windows-latest
@@ -27,6 +27,7 @@ jobs:
           - '5.32'
           - '5.34'
           - '5.38'
+          - '5.40'
 
       fail-fast: false
     name: perl${{ matrix.perl }}/${{ matrix.os }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,12 +18,15 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
+          - ubuntu-22.04
           # no libssl on windows
           # - windows-latest
 
         perl:
           - '5.30'
           - '5.32'
+          - '5.34'
+          - '5.38'
 
       fail-fast: false
     name: perl${{ matrix.perl }}/${{ matrix.os }}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,18 @@
+UNRELEASED - BREAKING CHANGE (warrants a major version bump)
+
+ - JSON-RPC 2.0 migration. callbackery.data.Server now uses
+   qx.io.jsonrpc.Client (qooxdoo 7.x) instead of the deprecated
+   qx.io.remote.Rpc. The JSON-RPC 2.0 dispatch now lives in
+   Mojolicious::Plugin::Qooxdoo >= 1.1.0, which auto-detects qx1 vs 2.0
+   requests, so the CallBackery backend can serve both old qx1 and new 2.0
+   frontends. The breaking part is the bundled 2.0-only
+   callbackery.data.Server frontend: applications must build against
+   qooxdoo 7.x, and must upgrade frontend and backend together.
+   The "qooxdoo/deprecated.qx.io.remote" requirement in the frontend
+   Manifest.json is no longer needed and may be dropped (CallBackery no
+   longer references qx.io.remote); leaving it in place is harmless, as
+   unreferenced library classes are not bundled.
+
 0.56.8 2026-03-27 16:21:24 +0100 Tobias Oetiker <tobi@oetiker.ch>
 
  - MockUser now has a controller method returning undef, so Abstract::log will fall through to $self->app->log instead of crashing.

--- a/CHANGES
+++ b/CHANGES
@@ -2,12 +2,16 @@ UNRELEASED - BREAKING CHANGE (warrants a major version bump)
 
  - JSON-RPC 2.0 migration. callbackery.data.Server now uses
    qx.io.jsonrpc.Client (qooxdoo 7.x) instead of the deprecated
-   qx.io.remote.Rpc. The JSON-RPC 2.0 dispatch now lives in
-   Mojolicious::Plugin::Qooxdoo >= 1.1.0, which auto-detects qx1 vs 2.0
-   requests, so the CallBackery backend can serve both old qx1 and new 2.0
-   frontends. The breaking part is the bundled 2.0-only
-   callbackery.data.Server frontend: applications must build against
-   qooxdoo 7.x, and must upgrade frontend and backend together.
+   qx.io.remote.Rpc. 
+
+   The JSON-RPC 2.0 dispatch now lives in Mojolicious::Plugin::Qooxdoo >= 1.1.0,
+    which auto-detects qx1 vs 2.0 requests, so the CallBackery backend can serve
+   both old qx1 and new 2.0 frontends. 
+
+   The breaking part is the bundled 2.0-only callbackery.data.Server
+   frontend: applications must build against qooxdoo 7.x, and must upgrade
+   frontend and backend together.
+
    The "qooxdoo/deprecated.qx.io.remote" requirement in the frontend
    Manifest.json is no longer needed and may be dropped (CallBackery no
    longer references qx.io.remote); leaving it in place is harmless, as

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-UNRELEASED - BREAKING CHANGE (warrants a major version bump)
+BREAKING CHANGE (warrants a major version bump)
 
  - JSON-RPC 2.0 migration. callbackery.data.Server now uses
    qx.io.jsonrpc.Client (qooxdoo 7.x) instead of the deprecated

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,7 @@ WriteMakefile(
   LICENSE      => 'gpl_3',
   PREREQ_PM    => {
     'Mojolicious' => '9.33',
-    'Mojolicious::Plugin::Qooxdoo' => '1.0.14',
+    'Mojolicious::Plugin::Qooxdoo' => '1.1.0',
     'Config::Grammar' => '1.13',
     'XS::Parse::Keyword' => '0.38',
     'Future::AsyncAwait' => '0.65',

--- a/docs/superpowers/plans/2026-06-11-jsonrpc-in-plugin.md
+++ b/docs/superpowers/plans/2026-06-11-jsonrpc-in-plugin.md
@@ -1,0 +1,536 @@
+# JSON-RPC 2.0 in mojolicious-plugin-qooxdoo — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add JSON-RPC 2.0 support to the reusable `Mojolicious::Plugin::Qooxdoo` plugin, where it auto-detects qx1 vs 2.0 per request, and have CallBackery's controller inherit it.
+
+**Architecture:** The plugin's `JsonRpcController::dispatch` gains a protocol-detection branch keyed on the presence of a `jsonrpc` member in the decoded request. A new `jsonRpc20` controller attribute records the mode; `renderJsonRpcResult` and `renderJsonRpcError` branch on it to emit either the legacy qx1 envelope or a strict 2.0 envelope. The legacy path is byte-for-byte unchanged, so existing consumers are unaffected (minor version bump 1.1.0). CallBackery requires the new plugin version and inherits the dispatcher — its controller carries no protocol overrides.
+
+**Tech Stack:** Perl 5, Mojolicious, `Mojo::JSON`, `Test::Mojo`. Two repos:
+- `PLUGIN` = `~/checkouts/mojolicious-plugin-qooxdoo` (fork `zaucker/`, branch `feature/jsonrpc-2.0`)
+- `CB` = `/home/zaucker/checkouts/callbackery` (branch `feature/qooxdoo7-jsonrpc`, PR #242)
+
+**Reference:** `docs/superpowers/specs/2026-06-11-jsonrpc-in-plugin-design.md`
+
+---
+
+## File Structure
+
+**PLUGIN repo:**
+- Modify: `lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm` — add `jsonRpc20` attribute; protocol detection in `dispatch`; mode-branching in `renderJsonRpcResult` / `renderJsonRpcError`; permissive params. Bump `$VERSION` → `1.1.0`.
+- Modify: `lib/Mojolicious/Plugin/Qooxdoo.pm` — bump `$VERSION` → `1.1.0`.
+- Modify: `Changes` — add 1.1.0 entry.
+- Modify: `t/simple.t` — append JSON-RPC 2.0 assertions (success, error, named-params, version/method/transport guards). The existing qx1 assertions stay untouched as the regression guard.
+
+**CB repo:**
+- Modify: `lib/CallBackery/Controller/RpcService.pm` — carries no protocol overrides; inherits `dispatch`/`renderJsonRpcResult`/`renderJsonRpcError` from the plugin (matches master).
+- Modify: `Makefile.PL` — dependency `'Mojolicious::Plugin::Qooxdoo' => '1.1.0'`.
+- Modify: `CHANGES` — refine the breaking-change wording.
+
+---
+
+## Task 1: Set up the plugin fork and confirm a green baseline
+
+**Files:** none modified (environment setup).
+
+- [ ] **Step 1: Fork and clone the plugin**
+
+```bash
+gh repo fork oetiker/mojolicious-plugin-qooxdoo --clone=false --remote=false 2>/dev/null || true
+cd ~/checkouts
+rm -rf mojolicious-plugin-qooxdoo
+git clone git@github.com:zaucker/mojolicious-plugin-qooxdoo.git
+cd ~/checkouts/mojolicious-plugin-qooxdoo
+git remote add upstream https://github.com/oetiker/mojolicious-plugin-qooxdoo.git
+git fetch upstream --quiet
+git checkout -b feature/jsonrpc-2.0 upstream/master
+```
+
+- [ ] **Step 2: Build the plugin's own thirdparty deps**
+
+Run: `cd ~/checkouts/mojolicious-plugin-qooxdoo && perl Makefile.PL && make thirdparty`
+Expected: completes; creates `thirdparty/lib/perl5` with `Test::Mojo` etc. (If `make thirdparty` fails on XS mismatch, `rm -rf thirdparty` and retry against the system perl — same gotcha as CallBackery.)
+
+- [ ] **Step 3: Run the existing test suite (baseline must be green)**
+
+Run: `cd ~/checkouts/mojolicious-plugin-qooxdoo && prove -lv t/simple.t`
+Expected: all assertions PASS (qx1 echo, async, exceptions, GET Script transport). This is the regression baseline — every later task must keep it green.
+
+- [ ] **Step 4: Commit the branch point (no-op marker)**
+
+No commit needed yet — the branch already points at `upstream/master`. Proceed to Task 2.
+
+---
+
+## Task 2: Detect JSON-RPC 2.0 and render the success envelope
+
+**Files:**
+- Modify: `~/checkouts/mojolicious-plugin-qooxdoo/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm`
+- Test: `~/checkouts/mojolicious-plugin-qooxdoo/t/simple.t`
+
+- [ ] **Step 1: Write the failing test** — append before `done_testing();` in `t/simple.t`:
+
+```perl
+# --- JSON-RPC 2.0 ---
+
+# 2.0 positional-params success
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","params"=>["hello"]})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,result=>'hello'},'2.0 success envelope')
+  ->content_type_is('application/json; charset=utf-8')
+  ->status_is(200);
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `prove -lv t/simple.t :: 2>&1 | grep -A3 '2.0 success'`
+Expected: FAIL — without the change the controller treats the request as qx1, errors on the missing `service`, so the body is not the 2.0 envelope.
+
+- [ ] **Step 3: Add the `jsonRpc20` attribute** — in `JsonRpcController.pm`, alongside the other `has` lines (after `has 'rpcParams';`):
+
+```perl
+has 'rpcParams';
+
+# true when the current request used the JSON-RPC 2.0 envelope
+has 'jsonRpc20';
+```
+
+- [ ] **Step 4: Add protocol detection + 2.0 request parsing in `dispatch`** — replace the whole block from `if (not defined $self->requestId){` down to (and including) the line `$self->methodName($method);` with:
+
+```perl
+    # Detect protocol: a 'jsonrpc' member selects strict JSON-RPC 2.0;
+    # its absence keeps the legacy qooxdoo "qx1" behaviour intact.
+    $self->jsonRpc20(defined $data->{jsonrpc} ? 1 : 0);
+
+    if (not defined $self->requestId){
+        my $error = "Missing 'id' property in JsonRPC request.";
+        $log->error($error);
+        $self->render(text => $error, status=>500);
+        return;
+    }
+
+    my $method;
+    if ($self->jsonRpc20) {
+        # --- JSON-RPC 2.0 ---
+        if ($data->{jsonrpc} ne '2.0') {
+            my $error = "Invalid 'jsonrpc' version (must be \"2.0\").";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        }
+        if ($self->crossDomain) {
+            my $error = "JSON-RPC 2.0 requests must be POST.";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        }
+        $method = $data->{method};
+        if (not defined $method) {
+            my $error = "Missing 'method' property in JsonRPC request.";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        }
+    }
+    else {
+        # --- legacy qx1 ---
+        # Check if service property is available
+        $data->{service} or do {
+            my $error = "Missing service property in JsonRPC request.";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        };
+        # Check if method is specified in the request
+        $method = $data->{method} or do {
+            my $error = "Missing method property in JsonRPC request.";
+            $log->error($error);
+            $self->render(text => $error, status=>500);
+            return;
+        };
+    }
+    $self->methodName($method);
+```
+
+(`crossDomain` is already set true only on the GET path, so reusing it as the "is GET" signal is correct.)
+
+- [ ] **Step 5: Guard the qx1-only service check inside the eval** — in `dispatch`, replace:
+
+```perl
+        die {
+            origin => 1,
+            message => "service $service not available",
+            code=> 2
+        } if not $self->service eq $service;
+```
+
+with:
+
+```perl
+        die {
+            origin => 1,
+            message => "service ".$data->{service}." not available",
+            code=> 2
+        } if not $self->jsonRpc20 and not $self->service eq $data->{service};
+```
+
+(The `my $service = ...` line was removed in Step 4, so reference `$data->{service}` directly.)
+
+- [ ] **Step 6: Branch `renderJsonRpcResult` on the mode** — replace its body:
+
+```perl
+sub renderJsonRpcResult {
+    my $self = shift;
+    my $data = shift;
+    my $reply = $self->jsonRpc20
+        ? { jsonrpc => '2.0', id => $self->requestId, result => $data }
+        : {                   id => $self->requestId, result => $data };
+    $self->logRpcReturn(dclone($reply));
+    $self->finalizeJsonRpcReply(encode_json($reply));
+}
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `prove -lv t/simple.t 2>&1 | grep -E '2.0 success|Result:'`
+Expected: `2.0 success envelope` PASS and overall `Result: PASS` (the qx1 assertions still pass).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd ~/checkouts/mojolicious-plugin-qooxdoo
+git add lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm t/simple.t
+git commit -m "feat: detect JSON-RPC 2.0 envelope and render 2.0 result"
+```
+
+---
+
+## Task 3: Render the JSON-RPC 2.0 error envelope
+
+**Files:**
+- Modify: `~/checkouts/mojolicious-plugin-qooxdoo/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm`
+- Test: `~/checkouts/mojolicious-plugin-qooxdoo/t/simple.t`
+
+- [ ] **Step 1: Write the failing tests** — append before `done_testing();`:
+
+```perl
+# 2.0 access-denied error (origin folded into data, integer code)
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"test"})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,error=>{code=>6,message=>"rpc access to method test denied",data=>{origin=>1}}},'2.0 access-denied envelope')
+  ->status_is(200);
+
+# 2.0 application exception propagated (blessed code+message -> origin 2)
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","params"=>[]})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,error=>{code=>123,message=>"Argument Required!",data=>{origin=>2}}},'2.0 exception envelope');
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `prove -lv t/simple.t 2>&1 | grep -E '2.0 (access-denied|exception)'`
+Expected: FAIL — current `renderJsonRpcError` always emits the qx1 shape (`{id,error:{origin,message,code}}`), not the 2.0 shape.
+
+- [ ] **Step 3: Rewrite `renderJsonRpcError` to branch on the mode** — replace the whole sub:
+
+```perl
+sub renderJsonRpcError {
+    my $self = shift;
+    my $exception = shift;
+    my ($origin, $message, $code);
+    for (ref $exception){
+        /HASH/ && $exception->{message} && do {
+            $origin  = $exception->{origin} // 2;
+            $message = $exception->{message};
+            $code    = $exception->{code};
+            last;
+        };
+        /.+/ && $exception->can('message') && $exception->can('code') && do {
+            $origin  = 2;
+            $message = $exception->message();
+            $code    = $exception->code();
+            last;
+        };
+        $self->log->error("Error while processing " . ($self->service // '') . "::" . $self->methodName . ": $exception");
+        $origin  = 2;
+        $message = "Couldn't process request";
+        $code    = 9999;
+    }
+    $self->log->error("JsonRPC error sent to client: '$code: $message'");
+
+    my $reply;
+    if ($self->jsonRpc20) {
+        # JSON-RPC 2.0: error.code must be an integer; non-standard 'origin'
+        # is carried inside the permitted 'data' member.
+        $reply = {
+            jsonrpc => '2.0',
+            id      => $self->requestId,
+            error   => {
+                code    => defined $code ? int($code) : 9999,
+                message => $message,
+                data    => { origin => $origin },
+            },
+        };
+    }
+    else {
+        $reply = {
+            id    => $self->requestId,
+            error => { origin => $origin || 2, message => $message, code => $code },
+        };
+    }
+    $self->finalizeJsonRpcReply(encode_json($reply));
+}
+```
+
+- [ ] **Step 4: Run to verify it passes (and qx1 errors still match)**
+
+Run: `prove -lv t/simple.t 2>&1 | grep -E '2.0 (access-denied|exception)|invalid service|invalid method|generic exception|Result:'`
+Expected: the two new `2.0 …` assertions PASS, the legacy `json error for invalid service` / `invalid method` / `propagating generic exception` still PASS, overall `Result: PASS`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm t/simple.t
+git commit -m "feat: render JSON-RPC 2.0 error envelope (integer code, origin in data)"
+```
+
+---
+
+## Task 4: Guard 2.0 version and transport
+
+**Files:**
+- Test: `~/checkouts/mojolicious-plugin-qooxdoo/t/simple.t` (implementation already added in Task 2 Step 4 — these tests lock it in)
+
+- [ ] **Step 1: Write the tests** — append before `done_testing();`:
+
+```perl
+# wrong jsonrpc version is rejected
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"1.0","id"=>1,"method"=>"echo","params"=>["hi"]})
+  ->content_like(qr/Invalid 'jsonrpc' version/,'2.0 version guard')
+  ->status_is(500);
+
+# 2.0 over GET (Script transport) is rejected
+$t->get_ok('/root/jsonrpc?_ScriptTransport_id=1&_ScriptTransport_data={"jsonrpc":"2.0","id":1,"method":"echo","params":["hi"]}')
+  ->content_like(qr/must be POST/,'2.0 POST-only guard')
+  ->status_is(500);
+```
+
+- [ ] **Step 2: Run to verify they pass**
+
+Run: `prove -lv t/simple.t 2>&1 | grep -E '2.0 (version|POST-only) guard|Result:'`
+Expected: both PASS, overall `Result: PASS`. (The logic was added in Task 2; this task is pure test coverage.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add t/simple.t
+git commit -m "test: cover JSON-RPC 2.0 version and POST-only guards"
+```
+
+---
+
+## Task 5: Permissive params (array splat or named-object hashref)
+
+**Files:**
+- Modify: `~/checkouts/mojolicious-plugin-qooxdoo/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm`
+- Test: `~/checkouts/mojolicious-plugin-qooxdoo/t/simple.t`
+
+- [ ] **Step 1: Write the failing test** — append before `done_testing();`. `echo` returns its first arg verbatim, so a named-object `params` must arrive as a single hashref and round-trip:
+
+```perl
+# 2.0 named (object) params are passed to the method as a single hashref
+$t->post_ok('/root/jsonrpc', json => {jsonrpc=>"2.0","id"=>1,"method"=>"echo","params"=>{name=>"bob"}})
+  ->json_is('',{jsonrpc=>"2.0",id=>1,result=>{name=>"bob"}},'2.0 named params reach method as hashref');
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `prove -lv t/simple.t 2>&1 | grep -E 'named params|Result:'`
+Expected: FAIL — the current invocation does `$self->$method(@{$self->rpcParams})`, which on a hashref throws "Not an ARRAY reference" (a 9999 error envelope), not the round-tripped hash.
+
+- [ ] **Step 3: Make invocation permissive** — in `dispatch`, replace:
+
+```perl
+        $self->logRpcCall($method,dclone($self->rpcParams));
+
+        # reply
+        no strict 'refs';
+        return $self->$method(@{$self->rpcParams});
+```
+
+with:
+
+```perl
+        $self->logRpcCall($method,dclone($self->rpcParams));
+
+        # reply
+        no strict 'refs';
+        my $params = $self->rpcParams;
+        if (ref $params eq 'ARRAY') {
+            return $self->$method(@$params);          # positional params
+        }
+        elsif (ref $params eq 'HASH') {
+            return $self->$method($params);           # named params -> single hashref
+        }
+        die {
+            origin  => 1,
+            message => "'params' must be an array or an object",
+            code    => 4
+        };
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `prove -lv t/simple.t 2>&1 | grep -E 'named params|post request|async request|Result:'`
+Expected: `named params …` PASS; the legacy array-param assertions (`post request`, `async request`) still PASS; overall `Result: PASS`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm t/simple.t
+git commit -m "feat: accept JSON-RPC 2.0 named (object) params as a hashref"
+```
+
+---
+
+## Task 6: Version bump and changelog
+
+**Files:**
+- Modify: `~/checkouts/mojolicious-plugin-qooxdoo/lib/Mojolicious/Plugin/Qooxdoo.pm`
+- Modify: `~/checkouts/mojolicious-plugin-qooxdoo/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm`
+- Modify: `~/checkouts/mojolicious-plugin-qooxdoo/Changes`
+
+- [ ] **Step 1: Bump `Qooxdoo.pm`** — change `our $VERSION = '1.0.14';` to:
+
+```perl
+our $VERSION = '1.1.0';
+```
+
+- [ ] **Step 2: Bump `JsonRpcController.pm`** — change `our $VERSION = '1.0.15';` to:
+
+```perl
+our $VERSION = '1.1.0';
+```
+
+(Note the pre-existing skew — the two files were out of sync at 1.0.14 / 1.0.15. This realigns them.)
+
+- [ ] **Step 3: Add the `Changes` entry** — insert at the very top of `Changes`:
+
+```
+1.1.0 2026-06-11 00:00:00 +0100 Fritz Zaucker <fritz.zaucker@oetiker.ch>
+
+ - support JSON-RPC 2.0 in addition to the legacy qooxdoo protocol; the
+   dispatcher auto-detects the envelope (a 'jsonrpc' member selects 2.0).
+   The 2.0 path drops the 'service' concept, is POST-only, returns
+   {jsonrpc,id,result|error}, uses an integer error code, carries the
+   non-standard 'origin' inside error.data, and accepts named (object)
+   params as a single hashref. Legacy qx1 behaviour is unchanged.
+ - realign $VERSION across Qooxdoo.pm and JsonRpcController.pm
+
+```
+
+(The maintainer's `make` release target restamps the date/author on release; the line above is a sensible placeholder.)
+
+- [ ] **Step 4: Run the full suite once more**
+
+Run: `cd ~/checkouts/mojolicious-plugin-qooxdoo && prove -lv t/simple.t t/source.t`
+Expected: `Result: PASS` for both — all legacy qx1 assertions plus the new 2.0 assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Mojolicious/Plugin/Qooxdoo.pm lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm Changes
+git commit -m "chore: release prep 1.1.0 (JSON-RPC 2.0 support)"
+```
+
+---
+
+## Task 7: Push the branch and open the plugin PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch to the fork**
+
+```bash
+cd ~/checkouts/mojolicious-plugin-qooxdoo
+git push -u origin feature/jsonrpc-2.0
+```
+
+- [ ] **Step 2: Open the PR against upstream**
+
+```bash
+gh pr create --repo oetiker/mojolicious-plugin-qooxdoo \
+  --base master --head zaucker:feature/jsonrpc-2.0 \
+  --title "Support JSON-RPC 2.0 (auto-detected) alongside the legacy protocol" \
+  --body-file /tmp/mpq-pr-body.md
+```
+
+Write `/tmp/mpq-pr-body.md` first, summarizing: auto-detection rule, the 2.0 envelope/semantics, backward compatibility (qx1 path unchanged, existing tests green), permissive params, minor version bump, and that it pairs with CallBackery PR #242. End with the Claude Code attribution line.
+
+- [ ] **Step 3: Record the PR URL**
+
+Run: `gh pr view --repo oetiker/mojolicious-plugin-qooxdoo --json url -q .url`
+Expected: prints the new PR URL. Note it for the CallBackery PR cross-reference.
+
+---
+
+## Task 8: CallBackery #242 — inherit from the plugin (local integration)
+
+**Files:**
+- Modify: `/home/zaucker/checkouts/callbackery/lib/CallBackery/Controller/RpcService.pm`
+- Modify: `/home/zaucker/checkouts/callbackery/Makefile.PL`
+- Modify: `/home/zaucker/checkouts/callbackery/CHANGES`
+
+- [ ] **Step 1: Ensure `RpcService.pm` carries no protocol overrides**
+
+`RpcService.pm` must inherit `dispatch`, `renderJsonRpcResult`, and `renderJsonRpcError` from the plugin — it defines none of them and does not `use Storable qw(dclone);`. It provides only the `%allow` map, `allow_rpc_access`, the password-cleaning `logRpcCall`/`logRpcReturn` overrides, and the RPC/upload/download methods (the controller's master shape).
+
+- [ ] **Step 2: Verify the file matches master exactly**
+
+Run: `cd /home/zaucker/checkouts/callbackery && git diff master -- lib/CallBackery/Controller/RpcService.pm | wc -l`
+Expected: `0` (no diff — the controller carries no protocol overrides).
+
+- [ ] **Step 3: Bump the plugin dependency in `Makefile.PL`** — change `'Mojolicious::Plugin::Qooxdoo' => '1.0.14',` to:
+
+```perl
+    'Mojolicious::Plugin::Qooxdoo' => '1.1.0',
+```
+
+- [ ] **Step 4: Stage the 1.1.0 plugin into CallBackery's thirdparty for local testing**
+
+(Until 1.1.0 is on CPAN, copy the branch's modules over the vendored 1.0.14 copy — exactly what `make thirdparty` will fetch post-release.)
+
+```bash
+cp ~/checkouts/mojolicious-plugin-qooxdoo/lib/Mojolicious/Plugin/Qooxdoo.pm \
+   /home/zaucker/checkouts/callbackery/thirdparty/lib/perl5/Mojolicious/Plugin/Qooxdoo.pm
+cp ~/checkouts/mojolicious-plugin-qooxdoo/lib/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm \
+   /home/zaucker/checkouts/callbackery/thirdparty/lib/perl5/Mojolicious/Plugin/Qooxdoo/JsonRpcController.pm
+```
+
+- [ ] **Step 5: Run CallBackery's RPC tests against the inherited dispatcher**
+
+Run: `cd /home/zaucker/checkouts/callbackery && prove -l t/basic.t t/jsonrpc.t`
+Expected: PASS. `t/jsonrpc.t` asserts the 2.0 success envelope (`{jsonrpc:"2.0",id:1,result:"pong"}`), the code-6 error envelope, and 500 on a non-2.0 body — all produced by the inherited plugin code, proving the inherited path is behavior-preserving.
+
+- [ ] **Step 6: Refine the `CHANGES` breaking-change wording** — update the UNRELEASED entry to note the new property: the 2.0 dispatch now lives in `Mojolicious::Plugin::Qooxdoo` ≥ 1.1.0 (auto-detecting), so the CallBackery *backend* serves both old qx1 and new 2.0 frontends; the breaking part is the bundled 2.0-only `callbackery.data.Server`, so apps still upgrade frontend + backend together. Keep the existing note that `deprecated.qx.io.remote` removal is optional.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/zaucker/checkouts/callbackery
+git add lib/CallBackery/Controller/RpcService.pm Makefile.PL CHANGES
+git commit -m "refactor: inherit JSON-RPC 2.0 dispatch from Mojolicious::Plugin::Qooxdoo 1.1.0
+
+RpcService inherits dispatch/renderJsonRpcResult/renderJsonRpcError from the
+plugin (auto-detecting qx1 vs 2.0); the controller carries no protocol
+overrides.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 8: Cross-link the PRs**
+
+Update PR #242's body (via `gh api repos/oetiker/callbackery/pulls/242 -X PATCH -F body=@…`, since `gh pr edit` fails on this repo's Projects-classic deprecation) to reference the plugin PR and note the release-ordering dependency (plugin 1.1.0 must land on CPAN before #242's `Makefile.PL` bump resolves).
+
+---
+
+## Notes on sequencing
+
+The `Makefile.PL` bump to `1.1.0` (Task 8 Step 3) only resolves from CPAN once the plugin PR (Task 7) is merged and released. Steps 4–5 validate the integration locally before that release. Do not run `make thirdparty` in CallBackery against a clean environment expecting 1.1.0 until the release exists — the staged copy in Step 4 is the interim.

--- a/docs/superpowers/specs/2026-06-11-jsonrpc-in-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-11-jsonrpc-in-plugin-design.md
@@ -1,0 +1,139 @@
+# Move JSON-RPC 2.0 dispatch into mojolicious-plugin-qooxdoo
+
+Date: 2026-06-11
+Status: Approved
+Related: PR #242 (CallBackery qooxdoo-7 / JSON-RPC 2.0 migration)
+
+## Problem
+
+CallBackery must run on qooxdoo 7.x, whose client speaks JSON-RPC 2.0
+(`qx.io.jsonrpc.Client`); the proprietary `qx.io.remote.Rpc` ("qx1") protocol
+is deprecated. The RPC protocol machinery belongs in the reusable,
+separately-versioned `Mojolicious::Plugin::Qooxdoo` plugin —
+`CallBackery::Controller::RpcService` is a thin subclass that provides only its
+`%allow` map, password-cleaning log overrides, and RPC methods, inheriting
+`dispatch`, `renderJsonRpcResult`, and `renderJsonRpcError` from
+`Mojolicious::Plugin::Qooxdoo::JsonRpcController`.
+
+The plugin, however, only speaks qx1. To put CallBackery on JSON-RPC 2.0 while
+keeping the protocol where it belongs, the plugin must learn JSON-RPC 2.0 and
+CallBackery must inherit it.
+
+## Goal
+
+Two coordinated PRs:
+
+1. **`mojolicious-plugin-qooxdoo`**: teach the plugin to speak JSON-RPC 2.0
+   *in addition to* qx1, auto-detecting per request. Backward compatible for
+   existing plugin consumers.
+2. **CallBackery PR #242**: require the new plugin version and inherit its 2.0
+   support; `RpcService.pm` carries no protocol overrides (a thin subclass).
+
+## Non-goals
+
+- No change to the frontend (`callbackery.data.Server` on `qx.io.jsonrpc.Client`,
+  `_jsonSafe` NaN handling).
+- No change to upload/download routes.
+- No removal of qx1 support from the plugin (other consumers may still use it).
+
+## Design
+
+### Part 1 — plugin: auto-detecting dispatcher
+
+In `Mojolicious::Plugin::Qooxdoo::JsonRpcController`:
+
+Add a controller attribute to record the detected protocol:
+
+```perl
+has 'jsonRpc20';   # true when the current request is JSON-RPC 2.0
+```
+
+`dispatch` decodes the body exactly as today (POST `application/json`, or the
+qx1 GET `_ScriptTransport_data` path), then branches on the envelope:
+
+- **`defined $data->{jsonrpc}`** → JSON-RPC 2.0 mode (`jsonRpc20(1)`):
+  - require `$data->{jsonrpc} eq '2.0'` else 500 with a clear message;
+  - POST-only — a GET in 2.0 mode is an error (2.0 has no Script transport /
+    crossDomain);
+  - **no `service` check** (2.0 drops the qx1 `service` concept);
+  - same downstream flow as qx1: `allow_rpc_access($method)` (die code 6 on
+    denial), `can($method)` (die code 4 if missing), `logRpcCall`, invoke,
+    `Mojo::Promise` handling, `render_later`.
+  - **params (permissive):** `params` may be an array or a named object.
+    - array → splat into the method arg list (`$self->$method(@$params)`), as
+      qx1 does;
+    - hashref → pass as a single argument (`$self->$method($params)`), so a
+      method can `my $args = shift`;
+    - anything else → 500 with a clear message.
+- **else** → existing qx1 mode (`jsonRpc20` false): behavior byte-for-byte
+  unchanged — `service` check, GET/crossDomain, etc.
+
+`renderJsonRpcResult` branches on `jsonRpc20`:
+
+```perl
+my $reply = $self->jsonRpc20
+    ? { jsonrpc => '2.0', id => $self->requestId, result => $data }
+    : {                   id => $self->requestId, result => $data };
+```
+
+`renderJsonRpcError` branches on `jsonRpc20`:
+
+- **2.0**: `{ jsonrpc => '2.0', id => $id, error => { code => int($code),
+  message => $message, data => { origin => $origin // 2 } } }` — `origin`
+  folded into `data` (2.0 forbids extra top-level error members), `code`
+  coerced to integer (2.0 requires an integer code).
+- **qx1**: `{ id => $id, error => { origin => $origin || 2, message, code } }`
+  — unchanged.
+
+The error classification (HASH-with-message / blessed-with-code+message /
+fallback 9999) is shared between both modes.
+
+`finalizeJsonRpcReply` is reused unchanged: in 2.0 mode `crossDomain` is always
+false, so it just sets `application/json` and renders.
+
+**Versioning:** 1.0.14 → **1.1.0** (additive, backward compatible). Bump
+`$VERSION` in both `Qooxdoo.pm` and `JsonRpcController.pm`, and `Changes`.
+
+### Part 2 — CallBackery (PR #242)
+
+- **`lib/CallBackery/Controller/RpcService.pm`**: carries no protocol overrides
+  — `dispatch`, `renderJsonRpcResult`, and `renderJsonRpcError` are inherited
+  from the plugin. It provides only the `%allow` map, `has service => 'default'`
+  (used in qx1 mode and in the error fallback log line), the password-cleaning
+  `logRpcCall`/`logRpcReturn` overrides, and the RPC methods.
+- **`Makefile.PL`**: `'Mojolicious::Plugin::Qooxdoo' => '1.1.0'`.
+- **`CHANGES`**: breaking-change entry. The *backend* is protocol-backward-
+  compatible (the plugin's auto-detect serves both old qx1 and new 2.0
+  frontends); the breaking part is the bundled 2.0-only
+  `callbackery.data.Server`, so apps upgrade frontend + backend together.
+- **`t/jsonrpc.t`, `t/basic.t`**: exercise the inherited 2.0 behavior
+  end-to-end.
+
+### Part 3 — tests & sequencing
+
+Plugin PR adds `t/` coverage:
+- 2.0 success envelope (`{jsonrpc:"2.0", id, result}`);
+- 2.0 error envelope with integer `code` and `data.origin`;
+- 2.0 named-object params reach the method as a hashref;
+- qx1 regression: existing tests stay green (the unchanged path).
+
+Sequencing:
+1. Implement the plugin change on a fork branch (`zaucker/…`), add tests,
+   open PR to `oetiker/mojolicious-plugin-qooxdoo`.
+2. Maintainer merges and releases 1.1.0 to CPAN.
+3. CallBackery #242 rebases, bumps `Makefile.PL`, `make thirdparty`, re-runs
+   `prove -l t/basic.t t/jsonrpc.t`.
+
+For local end-to-end testing before the CPAN release, build the plugin branch
+into CallBackery's `thirdparty/` (or `use lib` the plugin checkout, as the
+camas harness already does for CallBackery).
+
+## Risks
+
+- **Coupling / release order:** #242 cannot land its `Makefile.PL` bump until
+  1.1.0 is on CPAN. Mitigation: local build for testing; the maintainer owns
+  both repos and controls the release.
+- **Behavioral drift:** the plugin's 2.0 path must preserve the application
+  error codes the frontend depends on (6 = login required, 7 = session
+  expired). Mitigation: CallBackery's `t/jsonrpc.t` exercises the inherited
+  path end-to-end and guards these codes.

--- a/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/data/Server.js
+++ b/lib/CallBackery/qooxdoo/callbackery/source/class/callbackery/data/Server.js
@@ -7,68 +7,186 @@
 ************************************************************************ */
 
 /**
- * initialize us an Rpc object with some extra thrills.
+ * JSON-RPC 2.0 client for the CallBackery backend. Wraps
+ * {@link qx.io.jsonrpc.Client} while preserving the historic callback-style
+ * API (callAsync/callAsyncSmart/callAsyncSmartBusy with a (ret, exc, id)
+ * handler) so existing call sites keep working unchanged.
+ *
+ * @use(qx.io.transport.Xhr)
  */
 qx.Class.define("callbackery.data.Server", {
-    extend: qx.io.remote.Rpc,
+    extend: qx.core.Object,
     type: "singleton",
-
-    construct: function () {
-        this.base( arguments );
-        this.set( {
-            timeout: 180000,
-            url: 'QX-JSON-RPC/',
-            serviceName: 'default',
-            protocol: 'qx1'
-        });
-    },
 
     properties: {
         sessionCookie: {
             init: null,
             nullable: true
+        },
+        url: {
+            init: 'QX-JSON-RPC/',
+            check: 'String'
+        },
+        timeout: {
+            init: 180000,
+            check: 'Integer'
         }
     },
+
     members: {
+        __client: null,
+
         /**
-         * A asyncCall handler which tries to
-         * login in the case of a permission exception.
+         * Lazily create the JSON-RPC client and wire the session-cookie header.
+         * @return {qx.io.jsonrpc.Client}
+         */
+        _getClient: function() {
+            if (!this.__client) {
+                var self = this;
+                var transport = new qx.io.transport.Xhr(this.getUrl());
+                var client = new qx.io.jsonrpc.Client(transport);
+                client.addListener('outgoingRequest', function() {
+                    // getTransportImpl() creates a fresh impl that the
+                    // immediately-following Xhr.send() will pick up and reuse.
+                    var impl = transport.getTransportImpl();
+                    impl.setTimeout(self.getTimeout());
+                    var cookie = self.getSessionCookie();
+                    if (cookie) {
+                        impl.setRequestHeader('X-Session-Cookie', cookie);
+                    }
+                });
+                this.__client = client;
+            }
+            return this.__client;
+        },
+
+        /**
+         * Recursively replace non-finite numbers (NaN, Infinity) with null in
+         * plain data so the outgoing JSON is valid. qx.io.jsonrpc serialises
+         * via qx.util.Serializer.toJson, which emits a literal "NaN"/"Infinity"
+         * (invalid JSON the server rejects), whereas the legacy transport used
+         * JSON.stringify, which already mapped these to null. An empty numeric
+         * form field is the common source of NaN. Dates and qooxdoo objects are
+         * passed through untouched so the serialiser can handle them.
+         *
+         * @param v {var} value to sanitise
+         * @return {var} json-safe value
+         */
+        _jsonSafe: function(v) {
+            if (typeof v === 'number') {
+                return isFinite(v) ? v : null;
+            }
+            if (v === null || typeof v !== 'object' || v instanceof Date) {
+                return v;
+            }
+            if (qx.lang.Type.isArray(v)) {
+                var arr = [];
+                for (var i = 0; i < v.length; i++) {
+                    arr[i] = this._jsonSafe(v[i]);
+                }
+                return arr;
+            }
+            // only descend into plain data objects; leave qooxdoo objects intact
+            if (v.constructor === Object) {
+                var out = {};
+                for (var k in v) {
+                    if (Object.prototype.hasOwnProperty.call(v, k)) {
+                        out[k] = this._jsonSafe(v[k]);
+                    }
+                }
+                return out;
+            }
+            return v;
+        },
+
+        /**
+         * Perform the actual JSON-RPC call and adapt the promise to the
+         * historic (ret, exc, id) callback contract.
+         *
+         * @param handler {Function} callback(ret, exc, id)
+         * @param methodName {String} remote method
+         * @param params {Array} positional parameters
+         */
+        _send: function(handler, methodName, params) {
+            params = this._jsonSafe(params);
+            var invoke = function(ret, exc, id) {
+                try {
+                    handler(ret, exc, id);
+                }
+                catch (e) {
+                    if (window.console) {
+                        window.console.error("Error while running CallAsync Handler", "ret:", ret, "exc", exc, "id", id, "e", e);
+                    }
+                }
+            };
+            this._getClient().sendRequest(methodName, params).then(
+                function(result) {
+                    invoke(result, null, null);
+                },
+                function(ex) {
+                    // Only qx.io.exception.Protocol carries a server-supplied
+                    // application code (e.g. 6 = login required, 7 = session
+                    // expired). qx.io.exception.Transport/Cancel use their OWN
+                    // small-integer code namespace (TIMEOUT=1, CANCELLED=5,
+                    // FAILED=7) which must NOT be mistaken for an application
+                    // code - otherwise a network/HTTP error (Transport FAILED=7)
+                    // would trigger the session-expired page reload below.
+                    var exc = {
+                        code: ex && ex.code,
+                        message: (ex && ex.message) || String(ex),
+                        application: ex instanceof qx.io.exception.Protocol
+                    };
+                    invoke(null, exc, null);
+                }
+            );
+        },
+
+        /**
+         * A callAsync handler which tries to login in the case of a permission
+         * exception (code 6) and reloads on session expiry (code 7).
          *
          * @param handler {Function} the callback function.
          * @param methodName {String} the name of the method to call.
-         * @return {var} the method call reference.
          */
         callAsync: function(handler, methodName) {
-            if (methodName == 'login'){
-                // arguments.callee.base.apply(this, arguments);
-                arguments.callee.base.apply(this, arguments);
+            var args = Array.prototype.slice.call(arguments, 2);
+            if (methodName == 'login') {
+                // login is special: no locale, no exception interception
+                this._send(handler, methodName, args);
                 return;
             }
-            var origArguments = arguments;
             var origThis = this;
+            var origArgs = args;
+            var origMethod = methodName;
+            var origHandler = handler;
             var localeMgr = qx.locale.Manager.getInstance();
-            var newArgs = Array.prototype.slice.call(arguments);
-            newArgs[0] = function(ret, exc, id) {
-                if (exc) {
+            var wrapped = function(ret, exc, id) {
+                // only application (JSON-RPC protocol) errors carry the 6/7
+                // codes the login/session logic reacts to; transport errors
+                // fall through to the normal handler.
+                if (exc && exc.application) {
                     switch (exc.code) {
-                        case 6:
+                        case 6: {
+                            // permission denied: prompt for login, then retry once
                             let login = callbackery.ui.Login.getInstance();
                             login.addListenerOnce('login', (e) => {
-                                let ret = e.getData();
-                                origThis.setSessionCookie(ret.sessionCookie);
-                                origArguments.callee.base.apply(origThis, origArguments);
+                                let r = e.getData();
+                                origThis.setSessionCookie(r.sessionCookie);
+                                // retry the original call (without re-wrapping)
+                                origThis._send(origHandler, origMethod, origArgs);
                             });
                             login.open();
                             return;
-                        case 7:
-                            if (window.console){
+                        }
+                        case 7: {
+                            if (window.console) {
                                 window.console.log("Session Expired. Reloading page");
                             }
                             callbackery.ui.Busy.getInstance().vanish();
-                            let mb = callbackery.ui.MsgBox.getInstance()
-                            mb.addListenerOnce('choice',(e) => {
-                                if (e.getData() == 'ok'){
-                                     window.location.reload(true);
+                            let mb = callbackery.ui.MsgBox.getInstance();
+                            mb.addListenerOnce('choice', (e) => {
+                                if (e.getData() == 'ok') {
+                                    window.location.reload(true);
                                 }
                             });
                             mb.info(
@@ -76,36 +194,24 @@ qx.Class.define("callbackery.data.Server", {
                                 mb.xtr(exc.message)
                             );
                             return;
+                        }
                     }
                 }
-                try {
-                  handler(ret, exc, id);
-                }
-                catch(e) {
-                    if (window.console){
-                        window.console.error("Error while running CallAsync Handler","ret:",ret,"exc",exc,"id",id,"e",e);
-                    }
-                }
+                origHandler(ret, exc, id);
             };
-            newArgs.push({
-                qxLocale: localeMgr.getLocale()
-            });
-            arguments.callee.base.apply(this, newArgs);
+            var params = args.concat([{ qxLocale: localeMgr.getLocale() }]);
+            this._send(wrapped, methodName, params);
         },
+
         /**
-         * A variant of the asyncCall method which pops up error messages
-         * generated by the server automatically.
-         *
-         * Note that the handler method only gets a return value never an exception
-         * It just does not get called when there is an exception.
+         * A variant of callAsync which pops up server-generated error messages
+         * automatically. The handler only ever receives a return value.
          *
          * @param handler {Function} the callback function.
          * @param methodName {String} the name of the method to call.
-         * @return {var} the method call reference.
          */
         callAsyncSmart: function(handler, methodName) {
             var origHandler = handler;
-
             var superHandler = function(ret, exc, id) {
                 if (exc) {
                     callbackery.ui.MsgBox.getInstance().exc(exc);
@@ -117,6 +223,7 @@ qx.Class.define("callbackery.data.Server", {
             newArgs[0] = superHandler;
             this.callAsync.apply(this, newArgs);
         },
+
         callAsyncSmartBusy: function(handler, methodName) {
             var origHandler = handler;
             var busy = callbackery.ui.Busy.getInstance();
@@ -132,17 +239,6 @@ qx.Class.define("callbackery.data.Server", {
             newArgs[0] = superHandler;
             busy.manifest('Running ' + methodName);
             this.callAsync.apply(this, newArgs);
-        },
-        /**
-         * override the request creation, to add our 'cookie' header
-         */
-        createRequest: function() {
-            var req = this.base(arguments);
-            var cookie = this.getSessionCookie();
-            if (cookie) {
-                req.setRequestHeader('X-Session-Cookie', this.getSessionCookie());
-            }
-            return req;
         }
     }
 });

--- a/t/basic.t
+++ b/t/basic.t
@@ -23,10 +23,10 @@ $t->app->log->on(message => sub {
 
 
 for (1..2){
-    $t->post_ok('/QX-JSON-RPC' => json => { id => 1, service => 'default', method => 'ping'} )
+    $t->post_ok('/QX-JSON-RPC' => json => { jsonrpc => '2.0', id => 1, method => 'ping'} )
       ->status_is(200)
       ->content_type_is('application/json; charset=utf-8')
-      ->json_is({id => 1,result => "pong"});
+      ->json_is({jsonrpc => '2.0', id => 1, result => "pong"});
 
     $t->get_ok('/doc')
       ->content_like('/CallBackery::Index/')

--- a/t/jsonrpc.t
+++ b/t/jsonrpc.t
@@ -1,0 +1,36 @@
+use FindBin;
+use lib $FindBin::Bin.'/../thirdparty/lib/perl5';
+use lib $FindBin::Bin.'/../lib';
+
+use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+
+$ENV{CALLBACKERY_CONF} = $FindBin::Bin.'/callbackery.cfg';
+
+my $t = Test::Mojo->new('CallBackery');
+
+# JSON-RPC 2.0 success: no 'service' field, response carries jsonrpc:"2.0"
+$t->post_ok('/QX-JSON-RPC' => json => { jsonrpc => '2.0', id => 1, method => 'ping' })
+  ->status_is(200)
+  ->content_type_is('application/json; charset=utf-8')
+  ->json_is({ jsonrpc => '2.0', id => 1, result => 'pong' });
+
+# Access-denied method (unknown / not in %allow) -> JSON-RPC 2.0 error with the
+# integer code 6 preserved (the frontend's needs-login code). This is DB-free:
+# allow_rpc_access returns 0 for any method absent from %allow before any auth/DB
+# lookup. NOTE: code 6 (access denied) is checked before code 4 (method exists),
+# which is intentional - we don't reveal method existence to unauthorized callers.
+$t->post_ok('/QX-JSON-RPC' => json => { jsonrpc => '2.0', id => 2, method => 'nonesuch' })
+  ->status_is(200)
+  ->json_is('/jsonrpc' => '2.0')
+  ->json_is('/id' => 2)
+  ->json_is('/error/code' => 6)
+  ->json_like('/error/message' => qr/denied/)
+  ->json_hasnt('/result');   # error envelope must NOT carry a qx1 'result' key
+
+# Missing jsonrpc version is rejected (non-2.0 request)
+$t->post_ok('/QX-JSON-RPC' => json => { id => 3, method => 'ping' })
+  ->status_is(500);
+
+done_testing();


### PR DESCRIPTION
## Summary

Replaces the deprecated `qx.io.remote.Rpc` (qooxdoo proprietary *qx1* protocol) with the non-deprecated `qx.io.jsonrpc.Client` (strict JSON-RPC 2.0), so CallBackery builds and runs on **qooxdoo 7.x**.

The JSON-RPC 2.0 dispatch is **not carried in CallBackery** — it lives upstream in `Mojolicious::Plugin::Qooxdoo` (≥ 1.1.0), which auto-detects qx1 vs 2.0 per request (oetiker/mojolicious-plugin-qooxdoo#11, merged and released to CPAN as 1.1.0). `CallBackery::Controller::RpcService` simply **inherits** it, exactly as it did before this migration. This keeps protocol machinery in the reusable, separately-versioned plugin rather than duplicated downstream.

- **Backend** (`CallBackery::Controller::RpcService`): no protocol overrides — `dispatch` / `renderJsonRpcResult` / `renderJsonRpcError` are inherited from the plugin (the file returns to its `master` shape). `Makefile.PL` bumps the `Mojolicious::Plugin::Qooxdoo` requirement to `1.1.0`. The application error codes the frontend relies on (6 = login required, 7 = session expired) are preserved by the inherited 2.0 error envelope (`error.code` integer, `error.data.origin`). Upload/download routes untouched.
- **Frontend** (`callbackery.data.Server`): rewritten onto `qx.io.jsonrpc.Client` while keeping the public API (`callAsync` / `callAsyncSmart` / `callAsyncSmartBusy` with `(ret, exc, id)` handlers; `get/setSessionCookie`) — **no call-site changes**. Session cookie set via the `outgoingRequest` event; only `qx.io.exception.Protocol` errors are treated as application codes (transport errors no longer trigger a spurious session-expired reload); non-finite numbers (`NaN`/`Infinity`) are sanitized to `null` to match the old `JSON.stringify` wire behaviour.

**Breaking:** consuming apps must build against qooxdoo 7.x and must upgrade frontend + backend together — warrants a major version bump (see `CHANGES`). Because the plugin's dispatcher auto-detects the protocol, the *backend* can serve both old qx1 and new 2.0 frontends; the breaking part is the bundled 2.0-only `callbackery.data.Server`. The `qooxdoo/deprecated.qx.io.remote` requirement in an app's frontend `Manifest.json` is **no longer needed and may be dropped** (CallBackery no longer references `qx.io.remote`); leaving it in place is harmless, since unreferenced qooxdoo library classes are not bundled.

Design + implementation notes: `docs/superpowers/specs/` and `docs/superpowers/plans/`.

## Dependency

The plugin work (oetiker/mojolicious-plugin-qooxdoo#11) is **merged and released to CPAN as 1.1.0**, so the `Makefile.PL` requirement resolves on a clean `make thirdparty`. This PR is ready to merge.

## Test Plan

- [x] Plugin suite green on 1.1.0 (`prove -l t/simple.t t/source.t`, 79 pass): qx1 regression intact + 2.0 success/error/guards/named-params + direct-`render_later` 2.0 paths.
- [x] CallBackery RPC tests green against the **released CPAN 1.1.0** (`prove -l t/basic.t t/jsonrpc.t`, 29 pass): 2.0 ping success, code-6 access-denied error envelope, non-2.0 body → 500 — all produced by the inherited plugin code.
- [x] `RpcService.pm` is a zero-diff revert to `master` (protocol fully inherited).
- [x] Frontend compiles cleanly on qooxdoo 7.9.3 (verified against the `camas` app).
- [x] Live browser UAT against the `camas` backend: login + code-6 retry, table loads, plugin configs, PDF generation, session-cookie issuance, and form save (`processPluginData` → `{"action":"dataSaved"}` — the empty-numeric-field case that originally 500'd before the `NaN` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
