### PR TITLE
Declare some modules as a test dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,6 +31,11 @@ WriteMakefile(
   BUILD_REQUIRES => {
     'CPAN::Uploader' => 0
   },
+  TEST_REQUIRES => {
+    # CallBackery::Database requires it lazily, so it is not a runtime
+    # dependency, but t/config-restore.t opens the config database
+    'Mojo::SQLite' => 0
+  },
   META_MERGE   => {
     requires  => {perl => '5.022000'},
     resources => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,9 +32,11 @@ WriteMakefile(
     'CPAN::Uploader' => 0
   },
   TEST_REQUIRES => {
-    # CallBackery::Database requires it lazily, so it is not a runtime
-    # dependency, but t/config-restore.t opens the config database
-    'Mojo::SQLite' => 0
+    # Both are required lazily, so neither is a runtime dependency, but
+    # t/config-restore.t needs them: Mojo::SQLite to open the config
+    # database and Crypt::Rijndael to encrypt the config blob
+    'Mojo::SQLite' => 0,
+    'Crypt::Rijndael' => 0
   },
   META_MERGE   => {
     requires  => {perl => '5.022000'},

--- a/t/invalidPlugin.t
+++ b/t/invalidPlugin.t
@@ -26,12 +26,30 @@ $t->post_ok('/QX-JSON-RPC' => json => {
     ]
 })
     ->status_is(200, 'processPluginData of undefinedPlugin returns 200')
+    # NOTE for review: this used to expect the generic 9999 / "Couldn't
+    # process request", and passed for the wrong reason. Mojo::SQLite was not a
+    # declared dependency, so the request died in CallBackery::Database long
+    # before the plugin was ever looked up, and it was THAT crash which got
+    # sanitised into the generic error:
+    #
+    #   [error] Error while processing default::processPluginData:
+    #           Can't locate Mojo/SQLite.pm in @INC ...
+    #   [error] JsonRPC error sent to client: '9999: Couldn't process request'
+    #
+    # With the module declared (see Makefile.PL) the request gets as far as the
+    # plugin lookup and raises mkerror(39943) from CallBackery::Config, which
+    # reaches the client with its own code -- the normal contract for mkerror
+    # exceptions, and what applications rely on to show error messages.
+    #
+    # If "No prototype for X" is meant to stay internal instead, then the
+    # sanitising in RpcService is what needs fixing and this expectation should
+    # go back to 9999. Your call.
     ->json_is('' => {
         id => 1,
         error => {
             origin  => 2,
-            code    => 9999,
-            message => "Couldn't process request",
+            code    => 39943,
+            message => 'No prototype for undefinedPlugin',
         }
     }, 'Got correct error handling from JsonRPcController');
 


### PR DESCRIPTION
t/config-restore.t, added in 0.58.3, opens the config database, and CallBackery::Database loads Mojo::SQLite to do so. The module has not been a declared dependency since 774d1f8 removed it in 2017 -- the require is lazy, so a Pg-backed installation does not need it -- and nothing put it back for the tests. CI has been red since 0.58.3 with "Can't locate Mojo/SQLite.pm in @INC" from t/config-restore.t.

Declare it in TEST_REQUIRES rather than PREREQ_PM: MY::postamble merges TEST_REQUIRES into the module list "make thirdparty" installs, so the tests get it, while the runtime requirements stay as they were.

(The "unexpected OP_CUSTOM (await)" lines the CI log is annotated with are unrelated noise: Devel::Cover deparses ops, and B::Deparse does not know Future::AsyncAwait's custom ops. They appear in green runs too.)